### PR TITLE
Update Gleam dependencies

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,15 +13,16 @@ gleam_erlang = ">= 0.26.0 and < 1.0.0"
 gleam_json = ">= 2.0.0 and < 3.0.0"
 youid = ">= 1.2.0 and < 2.0.0"
 decode = ">= 0.2.1 and < 1.0.0"
-singularity = ">= 0.1.1 and < 1.0.0"
+singularity = { path = "../singularity" }
 logging = ">= 1.3.0 and < 2.0.0"
 pprint = ">= 1.0.3 and < 2.0.0"
 sqlight = ">= 0.9.1 and < 1.0.0"
-pog = ">= 1.0.0 and < 2.0.0"
+pog = ">= 3.0.0 and < 4.0.0"
 gtempo = ">= 5.0.2 and < 6.0.0"
 lamb = ">= 0.5.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 squirrel = ">= 2.0.0 and < 3.0.0"
+# squirrel = ">= 3.0.1 and < 4.0.0"
 envoy = ">= 1.0.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -23,6 +23,5 @@ lamb = ">= 0.5.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-squirrel = ">= 2.0.0 and < 3.0.0"
-# squirrel = ">= 3.0.1 and < 4.0.0"
+squirrel = ">= 3.0.1 and < 4.0.0"
 envoy = ">= 1.0.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,6 @@ gleam_erlang = ">= 0.26.0 and < 1.0.0"
 gleam_json = ">= 2.0.0 and < 3.0.0"
 youid = ">= 1.2.0 and < 2.0.0"
 decode = ">= 0.2.1 and < 1.0.0"
-singularity = { path = "../singularity" }
 logging = ">= 1.3.0 and < 2.0.0"
 pprint = ">= 1.0.3 and < 2.0.0"
 sqlight = ">= 0.9.1 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -33,7 +33,6 @@ packages = [
   { name = "pog", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "63152DADEBAE3150C81E9612909974C3C38F3E35B41F252798069A2FD117308E" },
   { name = "pprint", version = "1.0.4", build_tools = ["gleam"], requirements = ["glam", "gleam_stdlib"], otp_app = "pprint", source = "hex", outer_checksum = "C310A98BDC0995644847C3C8702DE19656D6BCD638B2A8A358B97824379ECAA1" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "singularity", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], source = "local", path = "../singularity" },
   { name = "sqlight", version = "0.9.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "A495F2892627B2268CCBCC5107EDC1E1AD9547D5F4F21A5DB04CEA72B8931B00" },
   { name = "squirrel", version = "3.0.1", build_tools = ["gleam"], requirements = ["argv", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "glexer", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "B0059A5C86E57D055B64F7591366117E2CF5EBD686BBA9470A1387D81A517DCB" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
@@ -55,7 +54,6 @@ lamb = { version = ">= 0.5.0 and < 1.0.0" }
 logging = { version = ">= 1.3.0 and < 2.0.0" }
 pog = { version = ">= 3.0.0 and < 4.0.0" }
 pprint = { version = ">= 1.0.3 and < 2.0.0" }
-singularity = { path = "../singularity" }
 sqlight = { version = ">= 0.9.1 and < 1.0.0" }
 squirrel = { version = ">= 3.0.1 and < 4.0.0" }
 youid = { version = ">= 1.2.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,17 +9,17 @@ packages = [
   { name = "esqlite", version = "0.8.9", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "465AE9AE28AE4192EA54C829FDC90C320447D439A9B2E10946621672FC6A6F8C" },
   { name = "eval", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "eval", source = "hex", outer_checksum = "264DAF4B49DF807F303CA4A4E4EBC012070429E40BE384C58FE094C4958F9BDA" },
   { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
-  { name = "glam", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "66EC3BCD632E51EED029678F8DF419659C1E57B1A93D874C5131FE220DFAD2B2" },
+  { name = "glam", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "4932A2D139AB0389E149396407F89654928D7B815E212BB02F13C66F53B1BBA1" },
   { name = "gleam_community_ansi", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "479DEDC748D08B310C9FEB9C4CBEC46B95C874F7F4F2844304D6D20CA78A8BB5" },
   { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
   { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
-  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
-  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
-  { name = "gleam_stdlib", version = "0.52.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "50703862DF26453B277688FFCDBE9DD4AC45B3BD9742C0B370DB62BC1629A07D" },
+  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
+  { name = "gleam_regexp", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "7F5E0C0BBEB3C58E57C9CB05FA9002F970C85AD4A63BA1E55CBCB35C15809179" },
+  { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
   { name = "gtempo", version = "5.1.2", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_yielder"], otp_app = "gtempo", source = "hex", outer_checksum = "61D128B30C7C165A7E08108465791AD2D85B181EC35C0289638F8CB94E28FCF9" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
   { name = "lamb", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "lamb", source = "hex", outer_checksum = "A74714DE60B3BADB623DFFF910C843793AE660222A9AD63C70053D33C0C3D311" },
@@ -29,12 +29,12 @@ packages = [
   { name = "opentelemetry_api", version = "1.4.0", build_tools = ["rebar3", "mix"], requirements = [], otp_app = "opentelemetry_api", source = "hex", outer_checksum = "3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58" },
   { name = "pg_types", version = "0.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "B02EFA785CAECECF9702C681C80A9CA12A39F9161A846CE17B01FB20AEEED7EB" },
   { name = "pgo", version = "0.14.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "71016C22599936E042DC0012EE4589D24C71427D266292F775EBF201D97DF9C9" },
-  { name = "pog", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "2F247BDCD6CD71AA6352BBFB4EE6E19B756D70810E6AB3EE060BA65232E3A1AC" },
+  { name = "pog", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "63152DADEBAE3150C81E9612909974C3C38F3E35B41F252798069A2FD117308E" },
   { name = "pprint", version = "1.0.4", build_tools = ["gleam"], requirements = ["glam", "gleam_stdlib"], otp_app = "pprint", source = "hex", outer_checksum = "C310A98BDC0995644847C3C8702DE19656D6BCD638B2A8A358B97824379ECAA1" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "singularity", version = "0.1.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "singularity", source = "hex", outer_checksum = "AF30FAF75D2D59A1F24DCC5BE6B902F374C115AE54BD0F8CAEDEC1E571BB77BF" },
+  { name = "singularity", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], source = "local", path = "../singularity" },
   { name = "sqlight", version = "0.9.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "A495F2892627B2268CCBCC5107EDC1E1AD9547D5F4F21A5DB04CEA72B8931B00" },
-  { name = "squirrel", version = "2.0.5", build_tools = ["gleam"], requirements = ["argv", "decode", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "738E9E82265A2096596CBAD78592BF7D9DC6B338E2310BC0E0032F88A24A43F3" },
+  { name = "squirrel", version = "2.1.0", build_tools = ["gleam"], requirements = ["argv", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "559B08E95B939ADFD2D958EA255F3A022CB6DBB2250B2126AD8A29C80D1C62A5" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
   { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
   { name = "tote", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tote", source = "hex", outer_checksum = "A249892E26A53C668897F8D47845B0007EEE07707A1A03437487F0CD5A452CA5" },
@@ -52,9 +52,9 @@ gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 gtempo = { version = ">= 5.0.2 and < 6.0.0" }
 lamb = { version = ">= 0.5.0 and < 1.0.0" }
 logging = { version = ">= 1.3.0 and < 2.0.0" }
-pog = { version = ">= 1.0.0 and < 2.0.0" }
+pog = { version = ">= 3.0.0 and < 4.0.0" }
 pprint = { version = ">= 1.0.3 and < 2.0.0" }
-singularity = { version = ">= 0.1.1 and < 1.0.0" }
+singularity = { path = "../singularity" }
 sqlight = { version = ">= 0.9.1 and < 1.0.0" }
 squirrel = { version = ">= 2.0.0 and < 3.0.0" }
 youid = { version = ">= 1.2.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -20,6 +20,7 @@ packages = [
   { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "glexer", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "F74FB4F78C3C1E158DF15A7226F33A662672F58EEF1DFE6593B7FCDA38B0A0EB" },
   { name = "gtempo", version = "5.1.2", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_yielder"], otp_app = "gtempo", source = "hex", outer_checksum = "61D128B30C7C165A7E08108465791AD2D85B181EC35C0289638F8CB94E28FCF9" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
   { name = "lamb", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "lamb", source = "hex", outer_checksum = "A74714DE60B3BADB623DFFF910C843793AE660222A9AD63C70053D33C0C3D311" },
@@ -34,7 +35,7 @@ packages = [
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
   { name = "singularity", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], source = "local", path = "../singularity" },
   { name = "sqlight", version = "0.9.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "A495F2892627B2268CCBCC5107EDC1E1AD9547D5F4F21A5DB04CEA72B8931B00" },
-  { name = "squirrel", version = "2.1.0", build_tools = ["gleam"], requirements = ["argv", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "559B08E95B939ADFD2D958EA255F3A022CB6DBB2250B2126AD8A29C80D1C62A5" },
+  { name = "squirrel", version = "3.0.1", build_tools = ["gleam"], requirements = ["argv", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "glexer", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "B0059A5C86E57D055B64F7591366117E2CF5EBD686BBA9470A1387D81A517DCB" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
   { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
   { name = "tote", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tote", source = "hex", outer_checksum = "A249892E26A53C668897F8D47845B0007EEE07707A1A03437487F0CD5A452CA5" },
@@ -56,5 +57,5 @@ pog = { version = ">= 3.0.0 and < 4.0.0" }
 pprint = { version = ">= 1.0.3 and < 2.0.0" }
 singularity = { path = "../singularity" }
 sqlight = { version = ">= 0.9.1 and < 1.0.0" }
-squirrel = { version = ">= 2.0.0 and < 3.0.0" }
+squirrel = { version = ">= 3.0.1 and < 4.0.0" }
 youid = { version = ">= 1.2.0 and < 2.0.0" }

--- a/src/bg_jobs/internal/postgres_db_adapter/sql.gleam
+++ b/src/bg_jobs/internal/postgres_db_adapter/sql.gleam
@@ -1,515 +1,11 @@
-import decode/zero
+import gleam/dynamic/decode
 import gleam/option.{type Option}
 import pog
 
-/// A row you get from running the `insert_succeeded_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/insert_succeeded_job.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type InsertSucceededJobRow {
-  InsertSucceededJobRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    succeeded_at: pog.Timestamp,
-  )
-}
-
-/// Runs the `insert_succeeded_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/insert_succeeded_job.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn insert_succeeded_job(db, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use succeeded_at <- zero.field(6, timestamp_decoder())
-    zero.success(InsertSucceededJobRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      succeeded_at:,
-    ))
-  }
-
-  let query =
-    "INSERT INTO
-    jobs_succeeded (
-        id,
-        name,
-        payload,
-        attempts,
-        created_at,
-        available_at,
-        succeeded_at
-    )
-VALUES
-    ($1, $2, $3, $4, $5, $6, $7)
-RETURNING
-    *;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.parameter(pog.text(arg_2))
-  |> pog.parameter(pog.text(arg_3))
-  |> pog.parameter(pog.int(arg_4))
-  |> pog.parameter(pog.timestamp(arg_5))
-  |> pog.parameter(pog.timestamp(arg_6))
-  |> pog.parameter(pog.timestamp(arg_7))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `get_failed_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_failed_jobs.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type GetFailedJobsRow {
-  GetFailedJobsRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    exception: String,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    failed_at: pog.Timestamp,
-  )
-}
-
-/// Runs the `get_failed_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_failed_jobs.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn get_failed_jobs(db, arg_1) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use exception <- zero.field(4, zero.string)
-    use created_at <- zero.field(5, timestamp_decoder())
-    use available_at <- zero.field(6, timestamp_decoder())
-    use failed_at <- zero.field(7, timestamp_decoder())
-    zero.success(GetFailedJobsRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      exception:,
-      created_at:,
-      available_at:,
-      failed_at:,
-    ))
-  }
-
-  let query =
-    "SELECT
-    *
-FROM
-    jobs_failed
-LIMIT
-    $1;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.int(arg_1))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// Runs the `delete_enqueued_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/delete_enqueued_job.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn delete_enqueued_job(db, arg_1) {
-  let decoder = zero.map(zero.dynamic, fn(_) { Nil })
-
-  let query =
-    "DELETE FROM
-    jobs
-WHERE
-    id = $1;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `get_running_jobs_by_queue_name` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_running_jobs_by_queue_name.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type GetRunningJobsByQueueNameRow {
-  GetRunningJobsByQueueNameRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    reserved_at: Option(pog.Timestamp),
-    reserved_by: Option(String),
-  )
-}
-
-/// Runs the `get_running_jobs_by_queue_name` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_running_jobs_by_queue_name.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn get_running_jobs_by_queue_name(db, arg_1) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(GetRunningJobsByQueueNameRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
-  }
-
-  let query =
-    "SELECT
-    *
-FROM
-    jobs
-WHERE
-    reserved_at <= CURRENT_TIMESTAMP
-    AND reserved_by = $1
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `get_succeeded_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_succeeded_jobs.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type GetSucceededJobsRow {
-  GetSucceededJobsRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    succeeded_at: pog.Timestamp,
-  )
-}
-
-/// Runs the `get_succeeded_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_succeeded_jobs.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn get_succeeded_jobs(db, arg_1) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use succeeded_at <- zero.field(6, timestamp_decoder())
-    zero.success(GetSucceededJobsRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      succeeded_at:,
-    ))
-  }
-
-  let query =
-    "SELECT
-    *
-FROM
-    jobs_succeeded
-LIMIT
-    $1;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.int(arg_1))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `increment_attempts` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/increment_attempts.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type IncrementAttemptsRow {
-  IncrementAttemptsRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    reserved_at: Option(pog.Timestamp),
-    reserved_by: Option(String),
-  )
-}
-
-/// Runs the `increment_attempts` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/increment_attempts.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn increment_attempts(db, arg_1) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(IncrementAttemptsRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
-  }
-
-  let query =
-    "UPDATE
-    jobs
-SET
-    attempts = attempts + 1
-WHERE
-    id = $1
-RETURNING
-    *;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `insert_failed_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/insert_failed_job.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type InsertFailedJobRow {
-  InsertFailedJobRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    exception: String,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    failed_at: pog.Timestamp,
-  )
-}
-
-/// Runs the `insert_failed_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/insert_failed_job.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn insert_failed_job(
-  db,
-  arg_1,
-  arg_2,
-  arg_3,
-  arg_4,
-  arg_5,
-  arg_6,
-  arg_7,
-  arg_8,
-) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use exception <- zero.field(4, zero.string)
-    use created_at <- zero.field(5, timestamp_decoder())
-    use available_at <- zero.field(6, timestamp_decoder())
-    use failed_at <- zero.field(7, timestamp_decoder())
-    zero.success(InsertFailedJobRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      exception:,
-      created_at:,
-      available_at:,
-      failed_at:,
-    ))
-  }
-
-  let query =
-    "INSERT INTO
-    jobs_failed (
-        id,
-        name,
-        payload,
-        attempts,
-        exception,
-        created_at,
-        available_at,
-        failed_at
-    )
-VALUES
-    ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING
-    *;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.parameter(pog.text(arg_2))
-  |> pog.parameter(pog.text(arg_3))
-  |> pog.parameter(pog.int(arg_4))
-  |> pog.parameter(pog.text(arg_5))
-  |> pog.parameter(pog.timestamp(arg_6))
-  |> pog.parameter(pog.timestamp(arg_7))
-  |> pog.parameter(pog.timestamp(arg_8))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
-/// A row you get from running the `enqueue_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/enqueue_job.sql`.
-///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
-/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub type EnqueueJobRow {
-  EnqueueJobRow(
-    id: String,
-    name: String,
-    payload: String,
-    attempts: Int,
-    created_at: pog.Timestamp,
-    available_at: pog.Timestamp,
-    reserved_at: Option(pog.Timestamp),
-    reserved_by: Option(String),
-  )
-}
-
-/// Runs the `enqueue_job` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/enqueue_job.sql`.
-///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
-/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
-///
-pub fn enqueue_job(db, arg_1, arg_2, arg_3, arg_4, arg_5) {
-  let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(EnqueueJobRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
-  }
-
-  let query =
-    "INSERT INTO
-    jobs (
-        id,
-        name,
-        payload,
-        attempts,
-        created_at,
-        available_at
-    )
-VALUES
-    ($1, $2, $3, 0, $4, $5)
-RETURNING
-    *;
-"
-
-  pog.query(query)
-  |> pog.parameter(pog.text(arg_1))
-  |> pog.parameter(pog.text(arg_2))
-  |> pog.parameter(pog.text(arg_3))
-  |> pog.parameter(pog.timestamp(arg_4))
-  |> pog.parameter(pog.timestamp(arg_5))
-  |> pog.returning(zero.run(_, decoder))
-  |> pog.execute(db)
-}
-
 /// A row you get from running the `release_jobs_reserved_by` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/release_jobs_reserved_by.sql`.
+/// defined in `./src/delete/sql/release_jobs_reserved_by.sql`.
 ///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
 /// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub type ReleaseJobsReservedByRow {
@@ -526,35 +22,36 @@ pub type ReleaseJobsReservedByRow {
 }
 
 /// Runs the `release_jobs_reserved_by` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/release_jobs_reserved_by.sql`.
+/// defined in `./src/delete/sql/release_jobs_reserved_by.sql`.
 ///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
+/// > 🐿️ This function was generated automatically using v3.0.1 of
 /// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub fn release_jobs_reserved_by(db, arg_1) {
   let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(ReleaseJobsReservedByRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      ReleaseJobsReservedByRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
   }
 
-  let query =
-    "UPDATE
+  "UPDATE
     jobs
 SET
     reserved_at = NULL,
@@ -564,17 +61,89 @@ WHERE
 RETURNING
     *;
 "
-
-  pog.query(query)
+  |> pog.query
   |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `enqueue_job` query
+/// defined in `./src/delete/sql/enqueue_job.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type EnqueueJobRow {
+  EnqueueJobRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    reserved_at: Option(pog.Timestamp),
+    reserved_by: Option(String),
+  )
+}
+
+/// Runs the `enqueue_job` query
+/// defined in `./src/delete/sql/enqueue_job.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn enqueue_job(db, arg_1, arg_2, arg_3, arg_4, arg_5) {
+  let decoder = {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      EnqueueJobRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
+  }
+
+  "INSERT INTO
+    jobs (
+        id,
+        name,
+        payload,
+        attempts,
+        created_at,
+        available_at
+    )
+VALUES
+    ($1, $2, $3, 0, $4, $5)
+RETURNING
+    *;
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.parameter(pog.text(arg_2))
+  |> pog.parameter(pog.text(arg_3))
+  |> pog.parameter(pog.timestamp(arg_4))
+  |> pog.parameter(pog.timestamp(arg_5))
+  |> pog.returning(decoder)
   |> pog.execute(db)
 }
 
 /// A row you get from running the `get_enqueued_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_enqueued_jobs.sql`.
+/// defined in `./src/delete/sql/get_enqueued_jobs.sql`.
 ///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
 /// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub type GetEnqueuedJobsRow {
@@ -591,35 +160,36 @@ pub type GetEnqueuedJobsRow {
 }
 
 /// Runs the `get_enqueued_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_enqueued_jobs.sql`.
+/// defined in `./src/delete/sql/get_enqueued_jobs.sql`.
 ///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
+/// > 🐿️ This function was generated automatically using v3.0.1 of
 /// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub fn get_enqueued_jobs(db, arg_1) {
   let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(GetEnqueuedJobsRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      GetEnqueuedJobsRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
   }
 
-  let query =
-    "SELECT
+  "SELECT
     *
 FROM
     jobs
@@ -627,17 +197,314 @@ WHERE
     name = $1
     AND reserved_at IS NULL
 "
-
-  pog.query(query)
+  |> pog.query
   |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `get_failed_jobs` query
+/// defined in `./src/delete/sql/get_failed_jobs.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type GetFailedJobsRow {
+  GetFailedJobsRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    exception: String,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    failed_at: pog.Timestamp,
+  )
+}
+
+/// Runs the `get_failed_jobs` query
+/// defined in `./src/delete/sql/get_failed_jobs.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn get_failed_jobs(db, arg_1) {
+  let decoder = {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use exception <- decode.field(4, decode.string)
+    use created_at <- decode.field(5, pog.timestamp_decoder())
+    use available_at <- decode.field(6, pog.timestamp_decoder())
+    use failed_at <- decode.field(7, pog.timestamp_decoder())
+    decode.success(
+      GetFailedJobsRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        exception:,
+        created_at:,
+        available_at:,
+        failed_at:,
+      ),
+    )
+  }
+
+  "SELECT
+    *
+FROM
+    jobs_failed
+LIMIT
+    $1;
+"
+  |> pog.query
+  |> pog.parameter(pog.int(arg_1))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `increment_attempts` query
+/// defined in `./src/delete/sql/increment_attempts.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type IncrementAttemptsRow {
+  IncrementAttemptsRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    reserved_at: Option(pog.Timestamp),
+    reserved_by: Option(String),
+  )
+}
+
+/// Runs the `increment_attempts` query
+/// defined in `./src/delete/sql/increment_attempts.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn increment_attempts(db, arg_1) {
+  let decoder = {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      IncrementAttemptsRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
+  }
+
+  "UPDATE
+    jobs
+SET
+    attempts = attempts + 1
+WHERE
+    id = $1
+RETURNING
+    *;
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `get_running_jobs_by_queue_name` query
+/// defined in `./src/delete/sql/get_running_jobs_by_queue_name.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type GetRunningJobsByQueueNameRow {
+  GetRunningJobsByQueueNameRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    reserved_at: Option(pog.Timestamp),
+    reserved_by: Option(String),
+  )
+}
+
+/// Runs the `get_running_jobs_by_queue_name` query
+/// defined in `./src/delete/sql/get_running_jobs_by_queue_name.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn get_running_jobs_by_queue_name(db, arg_1) {
+  let decoder = {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      GetRunningJobsByQueueNameRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
+  }
+
+  "SELECT
+    *
+FROM
+    jobs
+WHERE
+    reserved_at <= CURRENT_TIMESTAMP
+    AND reserved_by = $1
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// Runs the `delete_enqueued_job` query
+/// defined in `./src/delete/sql/delete_enqueued_job.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn delete_enqueued_job(db, arg_1) {
+  let decoder = decode.map(decode.dynamic, fn(_) { Nil })
+
+  "DELETE FROM
+    jobs
+WHERE
+    id = $1;
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `insert_failed_job` query
+/// defined in `./src/delete/sql/insert_failed_job.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type InsertFailedJobRow {
+  InsertFailedJobRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    exception: String,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    failed_at: pog.Timestamp,
+  )
+}
+
+/// Runs the `insert_failed_job` query
+/// defined in `./src/delete/sql/insert_failed_job.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn insert_failed_job(
+  db,
+  arg_1,
+  arg_2,
+  arg_3,
+  arg_4,
+  arg_5,
+  arg_6,
+  arg_7,
+  arg_8,
+) {
+  let decoder =
+  {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use exception <- decode.field(4, decode.string)
+    use created_at <- decode.field(5, pog.timestamp_decoder())
+    use available_at <- decode.field(6, pog.timestamp_decoder())
+    use failed_at <- decode.field(7, pog.timestamp_decoder())
+    decode.success(
+      InsertFailedJobRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        exception:,
+        created_at:,
+        available_at:,
+        failed_at:,
+      ),
+    )
+  }
+
+  "INSERT INTO
+    jobs_failed (
+        id,
+        name,
+        payload,
+        attempts,
+        exception,
+        created_at,
+        available_at,
+        failed_at
+    )
+VALUES
+    ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING
+    *;
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.parameter(pog.text(arg_2))
+  |> pog.parameter(pog.text(arg_3))
+  |> pog.parameter(pog.int(arg_4))
+  |> pog.parameter(pog.text(arg_5))
+  |> pog.parameter(pog.timestamp(arg_6))
+  |> pog.parameter(pog.timestamp(arg_7))
+  |> pog.parameter(pog.timestamp(arg_8))
+  |> pog.returning(decoder)
   |> pog.execute(db)
 }
 
 /// A row you get from running the `release_reservation` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/release_reservation.sql`.
+/// defined in `./src/delete/sql/release_reservation.sql`.
 ///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
 /// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub type ReleaseReservationRow {
@@ -654,35 +521,36 @@ pub type ReleaseReservationRow {
 }
 
 /// Runs the `release_reservation` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/release_reservation.sql`.
+/// defined in `./src/delete/sql/release_reservation.sql`.
 ///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
+/// > 🐿️ This function was generated automatically using v3.0.1 of
 /// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub fn release_reservation(db, arg_1) {
   let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(ReleaseReservationRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      ReleaseReservationRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
   }
 
-  let query =
-    "UPDATE
+  "UPDATE
     jobs
 SET
     reserved_at = NULL,
@@ -692,17 +560,150 @@ WHERE
 RETURNING
     *;
 "
-
-  pog.query(query)
+  |> pog.query
   |> pog.parameter(pog.text(arg_1))
-  |> pog.returning(zero.run(_, decoder))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `insert_succeeded_job` query
+/// defined in `./src/delete/sql/insert_succeeded_job.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type InsertSucceededJobRow {
+  InsertSucceededJobRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    succeeded_at: pog.Timestamp,
+  )
+}
+
+/// Runs the `insert_succeeded_job` query
+/// defined in `./src/delete/sql/insert_succeeded_job.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn insert_succeeded_job(db, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7,
+) {
+  let decoder =
+  {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use succeeded_at <- decode.field(6, pog.timestamp_decoder())
+    decode.success(
+      InsertSucceededJobRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        succeeded_at:,
+      ),
+    )
+  }
+
+  "INSERT INTO
+    jobs_succeeded (
+        id,
+        name,
+        payload,
+        attempts,
+        created_at,
+        available_at,
+        succeeded_at
+    )
+VALUES
+    ($1, $2, $3, $4, $5, $6, $7)
+RETURNING
+    *;
+"
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.parameter(pog.text(arg_2))
+  |> pog.parameter(pog.text(arg_3))
+  |> pog.parameter(pog.int(arg_4))
+  |> pog.parameter(pog.timestamp(arg_5))
+  |> pog.parameter(pog.timestamp(arg_6))
+  |> pog.parameter(pog.timestamp(arg_7))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `get_succeeded_jobs` query
+/// defined in `./src/delete/sql/get_succeeded_jobs.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type GetSucceededJobsRow {
+  GetSucceededJobsRow(
+    id: String,
+    name: String,
+    payload: String,
+    attempts: Int,
+    created_at: pog.Timestamp,
+    available_at: pog.Timestamp,
+    succeeded_at: pog.Timestamp,
+  )
+}
+
+/// Runs the `get_succeeded_jobs` query
+/// defined in `./src/delete/sql/get_succeeded_jobs.sql`.
+///
+/// > 🐿️ This function was generated automatically using v3.0.1 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn get_succeeded_jobs(db, arg_1) {
+  let decoder = {
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use succeeded_at <- decode.field(6, pog.timestamp_decoder())
+    decode.success(
+      GetSucceededJobsRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        succeeded_at:,
+      ),
+    )
+  }
+
+  "SELECT
+    *
+FROM
+    jobs_succeeded
+LIMIT
+    $1;
+"
+  |> pog.query
+  |> pog.parameter(pog.int(arg_1))
+  |> pog.returning(decoder)
   |> pog.execute(db)
 }
 
 /// A row you get from running the `get_running_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_running_jobs.sql`.
+/// defined in `./src/delete/sql/get_running_jobs.sql`.
 ///
-/// > 🐿️ This type definition was generated automatically using v2.0.0 of the
+/// > 🐿️ This type definition was generated automatically using v3.0.1 of the
 /// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub type GetRunningJobsRow {
@@ -719,59 +720,43 @@ pub type GetRunningJobsRow {
 }
 
 /// Runs the `get_running_jobs` query
-/// defined in `./src/bg_jobs/internal/postgres_db_adapter/sql/get_running_jobs.sql`.
+/// defined in `./src/delete/sql/get_running_jobs.sql`.
 ///
-/// > 🐿️ This function was generated automatically using v2.0.0 of
+/// > 🐿️ This function was generated automatically using v3.0.1 of
 /// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub fn get_running_jobs(db) {
   let decoder = {
-    use id <- zero.field(0, zero.string)
-    use name <- zero.field(1, zero.string)
-    use payload <- zero.field(2, zero.string)
-    use attempts <- zero.field(3, zero.int)
-    use created_at <- zero.field(4, timestamp_decoder())
-    use available_at <- zero.field(5, timestamp_decoder())
-    use reserved_at <- zero.field(6, zero.optional(timestamp_decoder()))
-    use reserved_by <- zero.field(7, zero.optional(zero.string))
-    zero.success(GetRunningJobsRow(
-      id:,
-      name:,
-      payload:,
-      attempts:,
-      created_at:,
-      available_at:,
-      reserved_at:,
-      reserved_by:,
-    ))
+    use id <- decode.field(0, decode.string)
+    use name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use attempts <- decode.field(3, decode.int)
+    use created_at <- decode.field(4, pog.timestamp_decoder())
+    use available_at <- decode.field(5, pog.timestamp_decoder())
+    use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
+    use reserved_by <- decode.field(7, decode.optional(decode.string))
+    decode.success(
+      GetRunningJobsRow(
+        id:,
+        name:,
+        payload:,
+        attempts:,
+        created_at:,
+        available_at:,
+        reserved_at:,
+        reserved_by:,
+      ),
+    )
   }
 
-  let query =
-    "SELECT
+  "SELECT
     *
 FROM
     jobs
 WHERE
     reserved_by IS NOT NULL
 "
-
-  pog.query(query)
-  |> pog.returning(zero.run(_, decoder))
+  |> pog.query
+  |> pog.returning(decoder)
   |> pog.execute(db)
-}
-
-// --- Encoding/decoding utils -------------------------------------------------
-
-/// A decoder to decode `timestamp`s coming from a Postgres query.
-///
-fn timestamp_decoder() {
-  use dynamic <- zero.then(zero.dynamic)
-  case pog.decode_timestamp(dynamic) {
-    Ok(timestamp) -> zero.success(timestamp)
-    Error(_) -> {
-      let date = pog.Date(0, 0, 0)
-      let time = pog.Time(0, 0, 0, 0)
-      zero.failure(pog.Timestamp(date:, time:), "timestamp")
-    }
-  }
 }

--- a/src/bg_jobs/internal/postgres_db_adapter/sql.gleam
+++ b/src/bg_jobs/internal/postgres_db_adapter/sql.gleam
@@ -37,18 +37,16 @@ pub fn release_jobs_reserved_by(db, arg_1) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      ReleaseJobsReservedByRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(ReleaseJobsReservedByRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "UPDATE
@@ -102,18 +100,16 @@ pub fn enqueue_job(db, arg_1, arg_2, arg_3, arg_4, arg_5) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      EnqueueJobRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(EnqueueJobRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "INSERT INTO
@@ -175,18 +171,16 @@ pub fn get_enqueued_jobs(db, arg_1) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      GetEnqueuedJobsRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(GetEnqueuedJobsRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "SELECT
@@ -238,18 +232,16 @@ pub fn get_failed_jobs(db, arg_1) {
     use created_at <- decode.field(5, pog.timestamp_decoder())
     use available_at <- decode.field(6, pog.timestamp_decoder())
     use failed_at <- decode.field(7, pog.timestamp_decoder())
-    decode.success(
-      GetFailedJobsRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        exception:,
-        created_at:,
-        available_at:,
-        failed_at:,
-      ),
-    )
+    decode.success(GetFailedJobsRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      exception:,
+      created_at:,
+      available_at:,
+      failed_at:,
+    ))
   }
 
   "SELECT
@@ -300,18 +292,16 @@ pub fn increment_attempts(db, arg_1) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      IncrementAttemptsRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(IncrementAttemptsRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "UPDATE
@@ -364,18 +354,16 @@ pub fn get_running_jobs_by_queue_name(db, arg_1) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      GetRunningJobsByQueueNameRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(GetRunningJobsByQueueNameRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "SELECT
@@ -448,8 +436,7 @@ pub fn insert_failed_job(
   arg_7,
   arg_8,
 ) {
-  let decoder =
-  {
+  let decoder = {
     use id <- decode.field(0, decode.string)
     use name <- decode.field(1, decode.string)
     use payload <- decode.field(2, decode.string)
@@ -458,18 +445,16 @@ pub fn insert_failed_job(
     use created_at <- decode.field(5, pog.timestamp_decoder())
     use available_at <- decode.field(6, pog.timestamp_decoder())
     use failed_at <- decode.field(7, pog.timestamp_decoder())
-    decode.success(
-      InsertFailedJobRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        exception:,
-        created_at:,
-        available_at:,
-        failed_at:,
-      ),
-    )
+    decode.success(InsertFailedJobRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      exception:,
+      created_at:,
+      available_at:,
+      failed_at:,
+    ))
   }
 
   "INSERT INTO
@@ -536,18 +521,16 @@ pub fn release_reservation(db, arg_1) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      ReleaseReservationRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(ReleaseReservationRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "UPDATE
@@ -590,10 +573,8 @@ pub type InsertSucceededJobRow {
 /// > 🐿️ This function was generated automatically using v3.0.1 of
 /// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
-pub fn insert_succeeded_job(db, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7,
-) {
-  let decoder =
-  {
+pub fn insert_succeeded_job(db, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7) {
+  let decoder = {
     use id <- decode.field(0, decode.string)
     use name <- decode.field(1, decode.string)
     use payload <- decode.field(2, decode.string)
@@ -601,17 +582,15 @@ pub fn insert_succeeded_job(db, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7,
     use created_at <- decode.field(4, pog.timestamp_decoder())
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use succeeded_at <- decode.field(6, pog.timestamp_decoder())
-    decode.success(
-      InsertSucceededJobRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        succeeded_at:,
-      ),
-    )
+    decode.success(InsertSucceededJobRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      succeeded_at:,
+    ))
   }
 
   "INSERT INTO
@@ -674,17 +653,15 @@ pub fn get_succeeded_jobs(db, arg_1) {
     use created_at <- decode.field(4, pog.timestamp_decoder())
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use succeeded_at <- decode.field(6, pog.timestamp_decoder())
-    decode.success(
-      GetSucceededJobsRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        succeeded_at:,
-      ),
-    )
+    decode.success(GetSucceededJobsRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      succeeded_at:,
+    ))
   }
 
   "SELECT
@@ -735,18 +712,16 @@ pub fn get_running_jobs(db) {
     use available_at <- decode.field(5, pog.timestamp_decoder())
     use reserved_at <- decode.field(6, decode.optional(pog.timestamp_decoder()))
     use reserved_by <- decode.field(7, decode.optional(decode.string))
-    decode.success(
-      GetRunningJobsRow(
-        id:,
-        name:,
-        payload:,
-        attempts:,
-        created_at:,
-        available_at:,
-        reserved_at:,
-        reserved_by:,
-      ),
-    )
+    decode.success(GetRunningJobsRow(
+      id:,
+      name:,
+      payload:,
+      attempts:,
+      created_at:,
+      available_at:,
+      reserved_at:,
+      reserved_by:,
+    ))
   }
 
   "SELECT

--- a/src/bg_jobs/postgres_db_adapter.gleam
+++ b/src/bg_jobs/postgres_db_adapter.gleam
@@ -707,11 +707,12 @@ fn timestamp_decoder() -> decode.Decoder(pog.Timestamp) {
 
   case decode.run(dynamic, pog.timestamp_decoder()) {
     Ok(timestamp) -> decode.success(timestamp)
-    Error(_) -> decode.success({
-      let date = pog.Date(0, 0, 0)
-      let time = pog.Time(0, 0, 0, 0)
+    Error(_) ->
+      decode.success({
+        let date = pog.Date(0, 0, 0)
+        let time = pog.Time(0, 0, 0, 0)
 
-      pog.Timestamp(date:, time:)
-    })
+        pog.Timestamp(date:, time:)
+      })
   }
 }


### PR DESCRIPTION
This updates some Gleam dependencies, and then fixes the resulting errors of the upgrade by converting to using `gleam/dynamic/decode` instead of `gleam/dynamic`.

The changes depend on https://github.com/jhillyerd/singularity/pull/13 though, so they aren't yet ready to be published, but I wanted to see if you'd like me to adjust anything, so figured I'd draft the PR now. Let me know if you'd like me to move anything around! :slightly_smiling_face: 